### PR TITLE
Highlights constants with improper naming convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,11 @@
 			{
                 "command": "extension.findAllErrors",
                 "title": "findAllErrors"
-            }
+            },
+			{
+				"command": "extension.findConstantCap",
+                "title": "findConstantCap"
+			}
 		],
 		"menus": {
 			"commandPalette": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { findLowercaseClassOrInterface } from './findLowercaseClassOrInterface';
 import { findCapitalizedMethodName } from './findCapitalizedMethodName';
 import { singleStatementPerLineChecker } from './singleStatementPerLineChecker';
 import { findAllErrors } from './findAllErrors';
+import { findConstantCap} from './findConstantCap';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Congratulations, your extension "Java convention commands" is now active!');
@@ -16,6 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     const disposable2 = vscode.commands.registerCommand('extension.findCapitalizedMethodName', findCapitalizedMethodName);
     const disposable3 = vscode.commands.registerCommand('extension.singleStatementPerLineChecker', singleStatementPerLineChecker);
     const disposable0 = vscode.commands.registerCommand('extension.findAllErrors', findAllErrors);
+	const disposable4 = vscode.commands.registerCommand('extension.findConstantCap', findConstantCap);
 
     
     const commentController = vscode.comments.createCommentController('comment-sample', 'Comment API Sample');

--- a/src/findConstantCap.ts
+++ b/src/findConstantCap.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+
+export function findConstantCap() {
+    // activeTextEditor allows access to text inside the opened document.
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+        const document = editor.document;
+        const text = document.getText();
+        const constantRegex = /(?<!\w)final\s+\w+\s+(\w+)\s*=/g;
+        let match;
+        const improperConstants = [];
+        while ((match = constantRegex.exec(text))) {
+            const constantName = match[1];
+            if (!isValidConstantName(constantName)) {
+                const constantStartPosition = document.positionAt(match.index);
+                const constantEndPosition = document.positionAt(match.index + constantName.length);
+                const range = new vscode.Range(constantStartPosition, constantEndPosition);
+                improperConstants.push(range);
+                vscode.window.showInformationMessage('Improper constant naming convention! Highlighted in RED');
+            }
+        }
+        if (improperConstants.length > 0) {
+            editor.setDecorations(improperConstantNameDecorationType, improperConstants);
+        } else {
+            vscode.window.showInformationMessage('All constants follow proper naming conventions!');
+        }
+    }
+}
+
+const improperConstantNameDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: 'rgba(255, 0, 0, 0.3)'
+});
+
+function isValidConstantName(constantName: string): boolean {
+    const pattern: RegExp = /^[A-Z][A-Z0-9_]*$/;
+    return pattern.test(constantName);
+}


### PR DESCRIPTION
This code identifies improperly named constants according to Java coding conventions. It will need to be updated to export line number where the error is found.