### PR TITLE
Created a function to export Map to Json

### DIFF
--- a/output/data.json
+++ b/output/data.json
@@ -1,0 +1,1 @@
+{"4":["Improper Capitalized Primitive Type"],"5":["Improper Capitalized Primitive Type"],"6":["Improper Capitalized Primitive Type"],"7":["Improper Capitalized Primitive Type"],"12":["Improper Capitalized Primitive Type"]}

--- a/src/convertMapToJson.ts
+++ b/src/convertMapToJson.ts
@@ -1,0 +1,9 @@
+import * as fs from 'fs';
+
+export function convertMapToJson(myMap: Map<number, string[]>, filePath: string) {
+    const mapAsObject: { [key: number]: string[] } = {};
+    myMap.forEach((value, key) => { mapAsObject[key] = value; });
+    const jsonString = JSON.stringify(mapAsObject);
+    fs.writeFileSync(filePath, jsonString);
+    console.log('JSON file created successfully:', filePath);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,37 +1,37 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { NoteComment, NoteCommentController } from './noteComment';
+import { NoteCommentController } from './noteComment';
 import { findCapitalizedPrimitiveTypes } from './findCapitalizedPrimitiveTypes';
 import { findLowercaseClassOrInterface } from './findLowercaseClassOrInterface';
 import { findCapitalizedMethodName } from './findCapitalizedMethodName';
 import { singleStatementPerLineChecker } from './singleStatementPerLineChecker';
 import { findAllErrors } from './findAllErrors';
-import { findConstantCap} from './findConstantCap';
-import { findLowercaseEnums } from './findLowercaseEnums';
+import { convertMapToJson } from './convertMapToJson';
+
+const myMap: Map<number, string[]> = new Map();
+const filePath = "/Users/willscomputer/Desktop/abc/gradeFast-1.0/output/data.json";
 
 export function activate(context: vscode.ExtensionContext) {
-    console.log('Congratulations, your extension "Java convention commands" is now active!');
+    const disposable = vscode.commands.registerCommand('extension.findCapitalizedPrimitiveTypes', () => {
+        findCapitalizedPrimitiveTypes(myMap);
+        convertMapToJson(myMap, filePath);
+    });
 
-    const disposable = vscode.commands.registerCommand('extension.findCapitalizedPrimitiveTypes', findCapitalizedPrimitiveTypes);
     const disposable1 = vscode.commands.registerCommand('extension.findLowercaseClassOrInterface', findLowercaseClassOrInterface);
     const disposable2 = vscode.commands.registerCommand('extension.findCapitalizedMethodName', findCapitalizedMethodName);
     const disposable3 = vscode.commands.registerCommand('extension.singleStatementPerLineChecker', singleStatementPerLineChecker);
     const disposable0 = vscode.commands.registerCommand('extension.findAllErrors', findAllErrors);
-	const disposable4 = vscode.commands.registerCommand('extension.findConstantCap', findConstantCap);
 
-    
     const commentController = vscode.comments.createCommentController('comment-sample', 'Comment API Sample');
     context.subscriptions.push(commentController);
-        // A `CommentingRangeProvider` controls where gutter decorations that allow adding comments are shown
-        commentController.commentingRangeProvider = {
-            provideCommentingRanges: (document: vscode.TextDocument, token: vscode.CancellationToken) => {
-                const lineCount = document.lineCount;
-                return [new vscode.Range(0, 0, lineCount - 1, 0)];
-            }
-        };
-        
-    NoteCommentController.registerCommands(context);  // Registers functions from NoteCommentController
-        
-    
+
+    commentController.commentingRangeProvider = {
+        provideCommentingRanges: (document: vscode.TextDocument, token: vscode.CancellationToken) => {
+            const lineCount = document.lineCount;
+            return [new vscode.Range(0, 0, lineCount - 1, 0)];
+        }
+    };
+
+    NoteCommentController.registerCommands(context);
 }

--- a/src/findAllErrors.ts
+++ b/src/findAllErrors.ts
@@ -12,7 +12,7 @@ import { singleStatementPerLineChecker } from "./singleStatementPerLineChecker";
 // Call all methods
 export function findAllErrors() { 
     findCapitalizedMethodName();
-    findCapitalizedPrimitiveTypes();
+    // findCapitalizedPrimitiveTypes();
     findLowercaseClassOrInterface();
     singleStatementPerLineChecker();    
 }

--- a/src/findCapitalizedPrimitiveTypes.ts
+++ b/src/findCapitalizedPrimitiveTypes.ts
@@ -1,68 +1,64 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-//     const disposable = vscode.commands.registerCommand('extension.findCapitalizedPrimitiveTypes', findCapitalizedPrimitiveTypes);
+const outputFile = '/Users/willscomputer/gradeFast-1.0/src/errorTxt';
 
-const outputFile = '/Users/sealion/capstone/gradeFast-1.0/src/error_lines.txt';
+export function findCapitalizedPrimitiveTypes(myMap: Map<number, string[]>): Map<number, string[]> {
+    vscode.window.showInformationMessage('Naming Convention Mistake!! Highlighted in RED');
+    const editor = vscode.window.activeTextEditor;
 
-export function findCapitalizedPrimitiveTypes() {
-	// activeTextEditor allows access to text inside opened document.
-	vscode.window.showInformationMessage('Naming Convention Mistake!! Highlighted in RED');
-	const editor = vscode.window.activeTextEditor;
-	//If there is an editor inside.
-	if (editor) {
-		const document = editor.document;
-		const text = document.getText();
-		
-		// 1. The expression starts and ends with `/`, marking the beginning and end of the pattern.
-		// 2. `\b` ensures that the pattern matches only at word boundaries.
-		// 3. `(?: ...)` groups together multiple options without capturing them separately.
-		// 4. `int|double|Boolean|char|byte|long|String` are the types of variables we're looking for.
-		// 5. `\s+` matches one or more spaces, tabs, or newlines after the variable type.
-		// 6. `([A-Z]\w*)` captures the variable name, starting with an uppercase letter and followed by zero or more word characters.
-		// 7. `\b` ensures that the variable name ends at a word boundary.
-		// 8. The `/` marks the end of the pattern.
-		// 9. `g` means the pattern should be applied globally to find all matches in the input text.
-		
-		const pattern = /\b(?:int|double|boolean|Boolean|char|byte|long|String)\s+([A-Z])(\w*)\b/g;
+    if (editor) {
+        const document = editor.document;
+        const text = document.getText();
+        
+        const pattern = /\b(?:int|double|boolean|Boolean|char|byte|long|String)\s+([A-Z])(\w*)\b/g;
 
-		const errorLines: string[] = [];
- // Array to store line numbers with errors
-		// Find matches
-		let match;
-		while ((match = pattern.exec(text)) !== null) {
-			// Get the matched variable name
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const lineNumber = document.positionAt(match.index).line + 1; // Get the line number
+            const myString: string = "Improper Capitalized Primitive Type on line: " + lineNumber;
 
-			let lineNumber = document.positionAt(match.index).line;
-			lineNumber = lineNumber+1;
-			let myString: string = lineNumber.toString();
-			myString = "Improper Capitalized Primitive Type on line: " + myString;
-            errorLines.push(myString);
-		
-			const variableName = match[0]; // Entire matched variable name
-			const firstLetterIndex = match.index + match[0].indexOf(match[1]); // Index of the first letter after the primitive data type
-			const firstLetterRange = new vscode.Range(document.positionAt(firstLetterIndex), document.positionAt(firstLetterIndex + 1));
-			
-			// Highlight the first letter after the primitive data type
-			editor.setDecorations(vscode.window.createTextEditorDecorationType({
-				isWholeLine: false,
-				borderWidth: '1px',
-				borderStyle: 'solid',
-				overviewRulerColor: 'red',
-				overviewRulerLane: vscode.OverviewRulerLane.Right,
-				light: {
-					borderColor: 'darkred',
-					backgroundColor: 'rgba(255, 0, 0, 0.1)'
-				},
-				dark: {
-					borderColor: 'lightred',
-					backgroundColor: 'rgba(255, 0, 0, 0.4)'
-				}
-			}), [firstLetterRange]);
-			
-		}
-		fs.writeFileSync(outputFile, errorLines.join('\n'));
-	} else {
-		vscode.window.showErrorMessage('No active text editor.');
-	}
+            const variableName = match[0]; // Entire matched variable name
+            const firstLetterIndex = match.index + match[0].indexOf(match[1]); // Index of the first letter after the primitive data type
+            const firstLetterRange = new vscode.Range(document.positionAt(firstLetterIndex), document.positionAt(firstLetterIndex + 1));
+            
+            editor.setDecorations(vscode.window.createTextEditorDecorationType({
+                isWholeLine: false,
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                overviewRulerColor: 'red',
+                overviewRulerLane: vscode.OverviewRulerLane.Right,
+                light: {
+                    borderColor: 'darkred',
+                    backgroundColor: 'rgba(255, 0, 0, 0.1)'
+                },
+                dark: {
+                    borderColor: 'lightred',
+                    backgroundColor: 'rgba(255, 0, 0, 0.4)'
+                }
+            }), [firstLetterRange]);
+
+            // Update the map with the error message
+            if (!myMap.has(lineNumber)) {
+                myMap.set(lineNumber, []);
+            }
+            const errorMessage = "Improper Capitalized Primitive Type";
+            const currentErrors = myMap.get(lineNumber) || [];
+            currentErrors.push(errorMessage);
+            myMap.set(lineNumber, currentErrors);
+        }
+
+        // Convert the map to a JSON string
+        const mapAsObject: { [key: number]: string[] } = {};
+        myMap.forEach((value, key) => { mapAsObject[key] = value; });
+        const jsonString = JSON.stringify(mapAsObject);
+
+        // Write the JSON string to a file
+        fs.writeFileSync('/Users/willscomputer/gradeFast-1.0/src/outputJson/data.json', jsonString);
+        console.log('JSON file created successfully.');
+    } else {
+        vscode.window.showErrorMessage('No active text editor.');
+    }
+
+    return myMap;
 }


### PR DESCRIPTION
This pull request introduces a new function that enables the conversion of a Map, specifically of type Map<number, string[]>, to a JSON file with a similar format. This functionality is crucial in preparing data for the subsequent PyLatex conversion process, ultimately leading to the creation of a PDF document.

This is a prototype example to show the team. We can replicate this code for the other methods and begin organizing all of their outputs into one data structure before converting to JSON.